### PR TITLE
clarify how to get `showlog` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,7 @@ LICENSE for more details.
 Please include the following in any bug reports.
 
 - `showlog` output from your device
+  - requires SSH access to your device
+    - see https://wiki.mobileread.com/wiki/Kindle_Touch_Hacking#USB_Networking
 - the firmware version of your device
 - your device model


### PR DESCRIPTION
The troubleshooting help isn't perfectly clear on how to get `showlog` output. Fix that.